### PR TITLE
Fix gendart when package has srv but no msg

### DIFF
--- a/src/gendart/generate.py
+++ b/src/gendart/generate.py
@@ -1145,14 +1145,14 @@ def generate_srv(pkg, files, out_dir, search_path):
     io.close()
 
 def msg_list(pkg, search_path, ext):
-    dir_list = search_path[pkg]
+    dir_list = search_path.get(pkg, [])
     files = []
     for d in dir_list:
         files.extend([f for f in os.listdir(d) if f.endswith(ext)])
     return [f[:-len(ext)] for f in files]
 
 def msg_list_full_path(pkg, search_path, ext):
-    dir_list = search_path[pkg]
+    dir_list = search_path.get(pkg, [])
     files = []
     for d in dir_list:
         files.extend([pjoin(d,f) for f in os.listdir(d) if f.endswith(ext)])


### PR DESCRIPTION
It seems that when package has no `msg/` directory generation fails.

Example of such package: https://github.com/rbonghi/ros_jetson_stats

Error message looks like this:

```
Traceback (most recent call last):
  File "/home/ml/ecobot/src/gendart/src/gendart/gendart_main.py", line 56, in genmain
    retcode = generate_srv(options.package, args[1:], options.outdir, search_path)
  File "/home/ml/ecobot/src/gendart/src/gendart/generate.py", line 1124, in generate_srv
    write_pubspec(s, pkg, search_path, msg_context, indir)
  File "/home/ml/ecobot/src/gendart/src/gendart/generate.py", line 980, in write_pubspec
    deps = get_all_dependent_pkgs(search_path, context, package, indir)
  File "/home/ml/ecobot/src/gendart/src/gendart/generate.py", line 942, in get_all_dependent_pkgs
    msgs = msg_list_full_path(package, search_path, '.msg')
  File "/home/ml/ecobot/src/gendart/src/gendart/generate.py", line 1156, in msg_list_full_path
    dir_list = search_path[pkg]
KeyError: 'ros_jetson_stats'
ERROR:  'ros_jetson_stats'
ros_jetson_stats/CMakeFiles/ros_jetson_stats_generate_messages_dart.dir/build.make:63: recipe for target '/home/ml/ecobot/devel/share/gendart/ros/ros_jetson_stats/fan.dart' failed
```

This PR fixes it