### PR TITLE
Fix version string to conform to schema

### DIFF
--- a/src/gendart/generate.py
+++ b/src/gendart/generate.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     from io import StringIO  # Python 3.x
 GenVersion = "0.1.0"
-DepVersion = '">=0.1.0 < 0.2.0"'
+DepVersion = '">=0.1.0 <0.2.0"'
 ############################################################
 # Built in types
 ############################################################
@@ -982,7 +982,7 @@ def write_pubspec(s, package, search_path, context, indir):
     s.newline()
     s.write('environment:')
     with Indent(s):
-        s.write('sdk: ">=2.12.0 < 3.0.0"')
+        s.write('sdk: ">=2.12.0 <3.0.0"')
     s.newline()
     s.write('dependencies:')
     with Indent(s):


### PR DESCRIPTION
Pubspec schema (https://json.schemastore.org/pubspec) defines version string without space between operator and version.

`">=2.12.0 < 3.0.0"` does not confirm to spec and shows as an error in VSCode

`">=2.12.0 <3.0.0"` passes validation