### PR TITLE
Definition of the 'messageDefinition' getter for RosServiceMessage re…

### DIFF
--- a/src/gendart/generate.py
+++ b/src/gendart/generate.py
@@ -936,6 +936,8 @@ def write_srv_end(s, context, spec):
         s.write('@override')
         s.write('String get fullType => \'{}\';'.format(
             spec.full_name))
+        s.write('@override')
+        s.write('String get messageDefinition => request.messageDefinition + "---" + response.messageDefinition;')
     s.write('}')
     s.newline()
 


### PR DESCRIPTION
I could not use messages generated by gendart with dartros because dart is asking to add an implementation of the getter 'messageDefinition' for each RosServiceMessage. 
So I basically added it, just by combining 'request.messageDefinition' and 'response.messageDefinition'.
I don't know if this is the best approach, but it's now working.